### PR TITLE
Replace reqwest with surf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "wallabag-api"
 edition = "2018"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Samuel Walladge <samuel@swalladge.net>"]
 license = "MIT OR Apache-2.0"
 description = "Client API library for Wallabag"
-repository = "https://github.com/swalladge/wallabag-rs"
+repository = "https://github.com/swalladge/wallabag-api"
 keywords = ["api", "wallabag"]
 categories = ["api-bindings"]
 readme = "README.md"
@@ -16,9 +16,10 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 chrono = { version = "0.4.6", features = ["serde"] }
 log = "0.4.6"
-reqwest = { version = "0.10.0", features = ["json"] }
 serde = { version = "1.0.82", features = ["derive"] }
 serde_json = "1.0.33"
+surf = "2.0.0-alpha.0"
+serde_urlencoded = "0.6.1"
 
 [dev-dependencies]
 tokio = { version = "0.2.13", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ surf = "2.0.0-alpha.0"
 serde_urlencoded = "0.6.1"
 
 [dev-dependencies]
-tokio = { version = "0.2.13", features = ["macros"] }
+async-std = "1.5.0"

--- a/examples/check_exists.rs
+++ b/examples/check_exists.rs
@@ -4,8 +4,7 @@ use std::result::Result;
 use wallabag_api::types::Config;
 use wallabag_api::Client;
 
-#[tokio::main]
-async fn main() -> Result<(), ()> {
+async fn run_example() -> Result<(), ()> {
     let config = Config {
         client_id: env::var("WALLABAG_CLIENT_ID").expect("WALLABAG_CLIENT_ID not set"),
         client_secret: env::var("WALLABAG_CLIENT_SECRET").expect("WALLABAG_CLIENT_SECRET not set"),
@@ -48,4 +47,8 @@ async fn main() -> Result<(), ()> {
             Ok(())
         }
     }
+}
+
+fn main() -> Result<(), ()> {
+    async_std::task::block_on(run_example())
 }

--- a/examples/example-sandbox.rs
+++ b/examples/example-sandbox.rs
@@ -8,8 +8,7 @@ use std::env;
 use wallabag_api::types::Config;
 use wallabag_api::Client;
 
-#[tokio::main]
-async fn main() {
+async fn run_example() {
     let config = Config {
         client_id: env::var("WALLABAG_CLIENT_ID").expect("WALLABAG_CLIENT_ID not set"),
         client_secret: env::var("WALLABAG_CLIENT_SECRET").expect("WALLABAG_CLIENT_SECRET not set"),
@@ -217,4 +216,8 @@ async fn main() {
     //     20398,
     // );
     // println!("{:#?}", res);
+}
+
+fn main() {
+    async_std::task::block_on(run_example())
 }

--- a/examples/get_entries.rs
+++ b/examples/get_entries.rs
@@ -3,8 +3,7 @@ use std::env;
 use wallabag_api::types::{Config, EntriesFilter, SortBy, SortOrder};
 use wallabag_api::Client;
 
-#[tokio::main]
-async fn main() {
+async fn run_example() {
     let config = Config {
         client_id: env::var("WALLABAG_CLIENT_ID").expect("WALLABAG_CLIENT_ID not set"),
         client_secret: env::var("WALLABAG_CLIENT_SECRET").expect("WALLABAG_CLIENT_SECRET not set"),
@@ -17,7 +16,7 @@ async fn main() {
 
     let mut client = Client::new(config);
 
-    /// Only get starred entries
+    // Only get starred entries
     let filter = EntriesFilter {
         archive: None,
         starred: Some(true),
@@ -46,4 +45,8 @@ async fn main() {
             }
         }
     }
+}
+
+fn main() {
+    async_std::task::block_on(run_example())
 }

--- a/examples/get_entries_page.rs
+++ b/examples/get_entries_page.rs
@@ -3,8 +3,7 @@ use std::env;
 use wallabag_api::types::{Config, EntriesFilter, SortBy, SortOrder};
 use wallabag_api::Client;
 
-#[tokio::main]
-async fn main() {
+async fn run_example() {
     let config = Config {
         client_id: env::var("WALLABAG_CLIENT_ID").expect("WALLABAG_CLIENT_ID not set"),
         client_secret: env::var("WALLABAG_CLIENT_SECRET").expect("WALLABAG_CLIENT_SECRET not set"),
@@ -42,4 +41,8 @@ async fn main() {
             );
         }
     }
+}
+
+fn main() {
+    async_std::task::block_on(run_example())
 }

--- a/examples/save_url.rs
+++ b/examples/save_url.rs
@@ -4,8 +4,7 @@ use std::result::Result;
 use wallabag_api::types::{Config, NewEntry};
 use wallabag_api::Client;
 
-#[tokio::main]
-async fn main() -> Result<(), ()> {
+async fn run_example() -> Result<(), ()> {
     let config = Config {
         client_id: env::var("WALLABAG_CLIENT_ID").expect("WALLABAG_CLIENT_ID not set"),
         client_secret: env::var("WALLABAG_CLIENT_SECRET").expect("WALLABAG_CLIENT_SECRET not set"),
@@ -40,4 +39,8 @@ async fn main() -> Result<(), ()> {
             Ok(())
         }
     }
+}
+
+fn main() -> Result<(), ()> {
+    async_std::task::block_on(run_example())
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,8 +5,8 @@ use std::fmt;
 
 use serde::Deserialize;
 use serde_urlencoded;
-use surf::{self, url};
 use surf::http::status::StatusCode;
+use surf::{self, url};
 
 pub type ClientResult<T> = std::result::Result<T, ClientError>;
 


### PR DESCRIPTION
This removes reqwest and replaces it with surf for http requests. It also updates the examples to use async-std instead of tokio just because it's possible. This should make things more executor agnostic and friendlier to users of this library.

Backwards incompatible, because the custom error struct needs to handle surf specific errors (which are very dynamic, so not as pretty as from reqwest).

Requesting comments on the error struct - I'm sure it could be nicer to use.