### PR TITLE
Bump surf to 2.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { version = "0.4.6", features = ["serde"] }
 log = "0.4.6"
 serde = { version = "1.0.82", features = ["derive"] }
 serde_json = "1.0.33"
-surf = "2.0.0-alpha.0"
+surf = "2.2.0"
 serde_urlencoded = "0.6.1"
 
 [dev-dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,9 +18,9 @@ use crate::errors::{
 };
 use crate::types::{
     Annotation, AnnotationRows, Annotations, Config, DeletedEntry, DeletedTag, Entries,
-    EntriesFilter, EntriesPage, Entry, ExistsInfo, ExistsResponse, Format, NewAnnotation, NewEntry,
-    NewlyRegisteredInfo, PaginatedEntries, PatchEntry, RegisterInfo, RequestEntriesFilter, Tag,
-    TagString, Tags, TokenInfo, User, ID, UNIT,
+    EntriesExistParams, EntriesFilter, EntriesPage, Entry, ExistsInfo, ExistsResponse, Format,
+    NewAnnotation, NewEntry, NewlyRegisteredInfo, PaginatedEntries, PatchEntry, RegisterInfo,
+    RequestEntriesFilter, Tag, TagString, Tags, TokenInfo, User, ID, UNIT,
 };
 use crate::utils::{EndPoint, UrlBuilder};
 
@@ -305,15 +305,13 @@ impl Client {
         &mut self,
         urls: Vec<T>,
     ) -> ClientResult<ExistsInfo> {
-        let mut params = vec![];
-        params.push(("return_id".to_owned(), "1".to_owned()));
-
-        // workaround: need to structure the params as a list of pairs since Vec
-        // values are unsupported:
-        // https://github.com/nox/serde_urlencoded/issues/46
-        for url in urls {
-            params.push(("urls[]".to_owned(), url.into()));
-        }
+        let params = EntriesExistParams {
+            return_id: 1,
+            urls: urls
+                .into_iter()
+                .map(|url| url.into())
+                .collect::<Vec<String>>(),
+        };
 
         self.smart_json_q(Method::Get, EndPoint::Exists, &params, UNIT)
             .await

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,8 +5,8 @@ use std::fmt;
 
 use serde::Deserialize;
 use serde_urlencoded;
-use surf::http::status::StatusCode;
-use surf::{self, url};
+use surf::http::StatusCode;
+use surf::{self, http::url};
 
 pub type ClientResult<T> = std::result::Result<T, ClientError>;
 
@@ -33,7 +33,7 @@ pub struct CodeMessage {
 /// Represents all error possibilities that could be returned by the client.
 #[derive(Debug)]
 pub enum ClientError {
-    SurfException(surf::Exception),
+    SurfError(surf::Error),
     SerdeJsonError(serde_json::error::Error),
     Unauthorized(ResponseError),
     Forbidden(ResponseCodeMessageError),
@@ -84,9 +84,9 @@ impl From<url::ParseError> for ClientError {
     }
 }
 
-impl From<surf::Exception> for ClientError {
-    fn from(err: surf::Exception) -> Self {
-        ClientError::SurfException(err)
+impl From<surf::Error> for ClientError {
+    fn from(err: surf::Error) -> Self {
+        ClientError::SurfError(err)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,6 +15,7 @@ mod entry;
 mod format;
 mod new_entry;
 mod patch_entry;
+mod query;
 mod tags;
 mod user;
 
@@ -29,6 +30,7 @@ pub use self::entry::{Entries, EntriesPage, Entry};
 pub use self::format::Format;
 pub use self::new_entry::NewEntry;
 pub use self::patch_entry::PatchEntry;
+pub(crate) use self::query::EntriesExistParams;
 pub use self::tags::{DeletedTag, Tag, TagString, Tags};
 pub use self::user::{NewlyRegisteredInfo, RegisterInfo, User};
 

--- a/src/types/query.rs
+++ b/src/types/query.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+// Represents parameters for the entry checking endpoint.
+pub(crate) struct EntriesExistParams {
+    pub return_id: usize,
+    pub urls: Vec<String>,
+}


### PR DESCRIPTION
Bump surf dependency from `2.0.0.alpha.0` to `2.2.0` so that a stable version is used.

In particular this PR
- Updates constants to `http_types` style (`Method::Post` instead of `Method::POST`...)
- Removes `?Sized` bound from JSON and query objects since it is no longer necessary.
- Uses `RequestBuilder` instead of a plain `Request` object to build a request (it is the recommended approach by `surf` docs now).
- Remove references to `surf::Exception` and use `surf::Error` instead (this is a breaking change).
- Update `check_urls_exists` to use a struct for the query since using a `Vec` is not supported by `serde_qs` (the new library used by `surf`)

I tested the examples on the `examples` folder against my personal Wallabag account on `wallabag.it`.